### PR TITLE
Troubleshoot docker compose build error

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -5,17 +5,18 @@ FROM node:18-alpine AS builder
 WORKDIR /app
 
 # Copy package files
-COPY server/package*.json ./
+COPY package*.json ./
+COPY yarn.lock ./
 COPY shared/ ../shared/
 
 # Install dependencies
-RUN npm ci --only=production && npm cache clean --force
+RUN yarn install --frozen-lockfile --production && yarn cache clean
 
 # Copy source code
-COPY server/ ./
+COPY . .
 
 # Build the application
-RUN npm run build
+RUN yarn build:server
 
 # Production stage
 FROM node:18-alpine AS production
@@ -49,4 +50,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
 
 # Start the application
-CMD ["node", "dist/index.js"]
+CMD ["node", "dist/server/node-build.mjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+
 
 services:
   # MongoDB Database


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix backend Docker build by correcting Dockerfile paths and commands for monorepo and Yarn usage.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `Dockerfile.server` was failing because it expected `package.json` in the `server/` directory, but it's located in the project root (monorepo setup). Additionally, it was using `npm` instead of `yarn` and had incorrect build/run commands for the server. These changes align the Dockerfile with the project's monorepo structure, Yarn usage, and server build process. The obsolete `version` attribute was also removed from `docker-compose.yml`.